### PR TITLE
screen option för smidigare användning

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ It is also possible to launch multiple picocom instances for monitoring and inte
 ```
 md407 screen /dev/ttyUSB*
 ```
-This option requires picocom to be installed and in path and alacritty (not a must, can be edited).
+This option requires picocom to be installed and in path. The terminal emulator to use can be change with the `EMULATOR` variable in the md407 script (default alacritty).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ screen /dev/ttyUSB0 115200
 ```
 115200 is the baudrate that needs to be used.
 
-It is also possible to launch multiple screen instances with
+It is also possible to launch multiple picocom instances for monitoring and interaction with
 ```
 md407 screen /dev/ttyUSB*
 ```
+This option requires picocom to be installed and in path and alacritty (not a must, can be edited).

--- a/README.md
+++ b/README.md
@@ -12,3 +12,8 @@ or you can use [screen](https://www.gnu.org/software/screen/) and run
 screen /dev/ttyUSB0 115200
 ```
 115200 is the baudrate that needs to be used.
+
+It is also possible to launch multiple screen instances with
+```
+md407 screen /dev/ttyUSB*
+```

--- a/bin/md407
+++ b/bin/md407
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Specifies PATH the terminal emulator (here alacritty) to use to launch with the OPTION 'screen'. Make sure the terminal to use use the -e option to run a command.
+EMULATOR=/usr/bin/alacritty
+
+
 for ARG in $1; do
   case $ARG in
     -h|--help)
@@ -9,7 +13,7 @@ The script will default to /dev/ttyUSB0 if you don't provide a port
 OPTIONS:
   go\t\t[port]\t\tSend the \"go\" command to the MD407.
   load\t<file>\t[port]\t\tLoad a file to the MD407.
-  screen\t[ports...]\tSpawn a new terminal (default alacritty) instance with 'picocom' for monitoring. Requires alacritty and picocom to be installed and in path.
+  screen\t[ports...]\tSpawn a new terminal instance with 'picocom' for monitoring. Requires picocom to be installed and in path. The terminal emulator can be changed with the EMULATOR variable in md407 script.
 
 A port can be optionally provided in the form \"/dev/ttyUSB1\" without the quotes.
 In the case of the 'screen' option multiple ports can be listed.";;
@@ -27,15 +31,15 @@ In the case of the 'screen' option multiple ports can be listed.";;
         fi;;
     screen)
 	if [ -z $2 ]; then
-	    # alacritty can be changed to another terminal but picocom is required to have correct output due to lf+cr problems
-	    alacritty -e picocom /dev/ttyUSB0 -b 115200 --imap lfcrlf &
+	    # picocom is required to have correct output due to lf+cr problems
+	    $EMULATOR -e picocom /dev/ttyUSB0 -b 115200 --imap lfcrlf &
 	else
 	    i=2
 	    while [ "$i" -le "$#" ]; do
   		eval "arg=\${$i}"
 		PORT=$arg
-	        # alacritty can be changed to another terminal but picocom is required to have correct output due to lf+cr problems
-		alacritty -e picocom $PORT -b 115200 --imap lfcrlf &
+	        # picocom is required to have correct output due to lf+cr problems
+		$EMULATOR -e picocom $PORT -b 115200 --imap lfcrlf &
   		i=$((i + 1))
 	    done
 	fi

--- a/bin/md407
+++ b/bin/md407
@@ -7,10 +7,12 @@ for ARG in $1; do
 The script will default to /dev/ttyUSB0 if you don't provide a port
 .
 OPTIONS:
-  go\t\t[port]\tSend the \"go\" command to the MD407.
-  load\t<file>\t[port]\tLoad a file to the MD407.
+  go\t\t[port]\t\tSend the \"go\" command to the MD407.
+  load\t<file>\t[port]\t\tLoad a file to the MD407.
+  screen\t[ports...]\tSpawn a new terminal (default alacritty) instance with 'screen' for monitoring.
 
-A port can be optionally provided in the form \"/dev/ttyUSB1\" without the quotes.";;
+A port can be optionally provided in the form \"/dev/ttyUSB1\" without the quotes.
+In the case of the 'screen' option multiple ports can be listed.";;
     load)
         if [ -z $3 ]; then
             echo -e "load\n" | cat - $2 > /dev/ttyUSB0
@@ -23,6 +25,19 @@ A port can be optionally provided in the form \"/dev/ttyUSB1\" without the quote
         else
             echo -e "go\n" > $2
         fi;;
+    screen)
+	if [-z $2 ]; then
+	    alacritty -e screen /dev/ttyUSB0 115200 &
+	else
+	    i=2
+	    while [ "$i" -le "$#" ]; do
+  		eval "arg=\${$i}"
+		PORT=$arg
+		alacritty -e screen $PORT 115200 &
+  		i=$((i + 1))
+	    done
+	fi
+	;;
     *)
       echo -e "md407: you must specify a command.
 Try \"md407 --help\" for more information" ;;

--- a/bin/md407
+++ b/bin/md407
@@ -9,7 +9,7 @@ The script will default to /dev/ttyUSB0 if you don't provide a port
 OPTIONS:
   go\t\t[port]\t\tSend the \"go\" command to the MD407.
   load\t<file>\t[port]\t\tLoad a file to the MD407.
-  screen\t[ports...]\tSpawn a new terminal (default alacritty) instance with 'screen' for monitoring.
+  screen\t[ports...]\tSpawn a new terminal (default alacritty) instance with 'picocom' for monitoring. Requires alacritty and picocom to be installed and in path.
 
 A port can be optionally provided in the form \"/dev/ttyUSB1\" without the quotes.
 In the case of the 'screen' option multiple ports can be listed.";;
@@ -26,14 +26,16 @@ In the case of the 'screen' option multiple ports can be listed.";;
             echo -e "go\n" > $2
         fi;;
     screen)
-	if [-z $2 ]; then
-	    alacritty -e screen /dev/ttyUSB0 115200 &
+	if [ -z $2 ]; then
+	    # alacritty can be changed to another terminal but picocom is required to have correct output due to lf+cr problems
+	    alacritty -e picocom /dev/ttyUSB0 -b 115200 --imap lfcrlf &
 	else
 	    i=2
 	    while [ "$i" -le "$#" ]; do
   		eval "arg=\${$i}"
 		PORT=$arg
-		alacritty -e screen $PORT 115200 &
+	        # alacritty can be changed to another terminal but picocom is required to have correct output due to lf+cr problems
+		alacritty -e picocom $PORT -b 115200 --imap lfcrlf &
   		i=$((i + 1))
 	    done
 	fi

--- a/bin/md407
+++ b/bin/md407
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Specifies PATH the terminal emulator (here alacritty) to use to launch with the OPTION 'screen'. Make sure the terminal to use use the -e option to run a command.
+# Specifies PATH the terminal emulator (here alacritty) to use to launch with the OPTION 'screen'. Make sure the terminal uses the -e option to run a command.
 EMULATOR=/usr/bin/alacritty
 
 

--- a/bin/setMD407baud
+++ b/bin/setMD407baud
@@ -6,14 +6,14 @@ if [ -z $1 ]; then
     PORT=$(dmesg | tail -1 | grep -oE "[^ ]+$")
 
     # Change terminal line settings.
-    stty -F "/dev/$PORT" 115200 ignpar -icrnl -opost -isig -icanon -echo cols 60 rows 20
+    stty -F "/dev/$PORT" 115200 ignpar -icrnl -opost -isig -icanon -echo
 else
     # do the same for every device in arguments
     i=1
     while [ "$i" -le "$#" ]; do
   	eval "arg=\${$i}"
 	PORT=$arg
-	stty -F "$PORT" 115200 ignpar -icrnl -opost -isig -icanon -echo cols 60 rows 20
+	stty -F "$PORT" 115200 ignpar -icrnl -opost -isig -icanon -echo
   	i=$((i + 1))
     done
 fi

--- a/bin/setMD407baud
+++ b/bin/setMD407baud
@@ -1,7 +1,20 @@
 #!/bin/sh
+# Usage: setMD407baud [ports..]
 
-# Get last connected device
-PORT=$(dmesg | tail -1 | grep -oE "[^ ]+$")
+if [ -z $1 ]; then
+    # Get last connected device
+    PORT=$(dmesg | tail -1 | grep -oE "[^ ]+$")
 
-# Change terminal line settings.
-stty -F "/dev/$PORT" 115200 ignpar -icrnl -opost -isig -icanon -echo
+    # Change terminal line settings.
+    stty -F "/dev/$PORT" 115200 ignpar -icrnl -opost -isig -icanon -echo cols 60 rows 20
+else
+    # do the same for every device in arguments
+    i=1
+    while [ "$i" -le "$#" ]; do
+  	eval "arg=\${$i}"
+	PORT=$arg
+	stty -F "$PORT" 115200 ignpar -icrnl -opost -isig -icanon -echo cols 60 rows 20
+  	i=$((i + 1))
+    done
+fi
+


### PR DESCRIPTION
Lägg till en screen option till md407 för att launcha picocom instances på separat terminal som respektrar line breaks i utskriften. Detta pga av CR/LF problemet med det md407 skickar.